### PR TITLE
Add support of Chatwork API usage limits.

### DIFF
--- a/src/ChatworkApi.php
+++ b/src/ChatworkApi.php
@@ -10,6 +10,21 @@ class ChatworkApi
     public static $apiKey = '';
 
     /**
+     * @var int usageLimitMax
+     */
+    public $usageLimitMax = null;
+
+    /**
+     * @var int usageLimitRemaining
+     */
+    public $usageLimitRemaining = null;
+
+    /**
+     * @var int usageLimitResetTime
+     */
+    public $usageLimitResetTime = null;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -441,6 +456,10 @@ class ChatworkApi
         $request->setParams($params);
 
         $response = $request->send();
+
+        $this->usageLimitMax = intval($response['usage_limit_max']);
+        $this->usageLimitRemaining = intval($response['usage_limit_remaining']);
+        $this->usageLimitResetTime = intval($response['usage_limit_reset_time']);
 
         return $response['response'];
     }


### PR DESCRIPTION
Add support of Chatwork API usage limits.
You can get API Usage Limits information after successfull API call.

By the way,
I had to edit tests/ChatworkTestBase.php to run tests on my local environment. (using PHPUnit 7.4.4)

From
`class ChatworkTestBase extends PHPUnit_Framework_TestCase`

To
`class ChatworkTestBase extends \PHPUnit\Framework\TestCase`

I think this library should add phpunit into composer.json .